### PR TITLE
fix the reference to the schema and resolver modules

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -4,8 +4,6 @@ module.exports = {
         graphql: '/graphql',
         graphiql: '/graphiql'
     },
-    paths: {
-        resolvers: require('./resolvers'),
-        schemas: require('./schemas')
-    }
+    resolvers: require('./resolvers'),
+    schemas: require('./schemas')
 };


### PR DESCRIPTION
# Why

Inadvertently left the default resolver and schema reference as a path object.