### PR TITLE
Allow executable schemas to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ const { init } = require('cnn-starter-api');
 ...
 
 init({
+    executableSchema: executableSchema,  // resolvers and schemas are ignored if this is set
     middleware: [
         myMiddleware
-    ]
+    ],
     routes: {
         graphql: '/my_graphql',
         graphiql: '/my_graphiql'
@@ -47,7 +48,7 @@ init({
 });
 ```
 
-## Run The Example
+## Run the example
 
 ```
 $ npm run test

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function init(appConfig) {
     const config = Object.assign({}, defaultConfig, appConfig),
         schemas = config.schemas || require('./defaults/schemas'),
         resolvers = config.resolvers || require('./defaults/resolvers'),
-        executableSchema = makeExecutableSchema({
+        executableSchema = config.executableSchema || makeExecutableSchema({
             typeDefs: schemas,
             resolvers: resolvers
         });


### PR DESCRIPTION
# Why

Allow executable schemas to be passed when the server is initialized.