### PR TITLE
Feature/use correct config path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function init(appConfig) {
             {
                 path: config.paths.graphiql,
                 handler: graphiqlExpress({
-                    endpointURL: config.routes.graphql,
+                    endpointURL: config.paths.graphql,
                     passHeader: `"${apiGatewayKeyName}": "${apiGatewayKey}"`
                 })
             }


### PR DESCRIPTION
# Why

- Use the correct config.paths for endpointURL

- Remove that package-lock.json