### PR TITLE
Feature/add graphiql flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ init();
 
 ```
 {
-    flags: {
-        enableCors: true,
-        graphiql: false
-    },
+    enableCors: true,
+    enableGraphiql: false,
     headers: {
         graphiql: '"X-Starter-API": "Started"'
     },

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ init();
 
 ```
 {
+    flags: {
+        enableCors: true,
+        graphiql: false
+    },
+    headers: {
+        graphiql: '"X-Starter-API": "Started"'
+    },
+    middleware: [],
     paths: {
         graphql: '/graphql',
         graphiql: '/graphiql'

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ init();
 
 ```
 {
-    enableCors: true,
-    enableGraphiql: false,
+    flags: {
+        cors: true,
+        graphiql: false
+    },
     headers: {
         graphiql: '"X-Starter-API": "Started"'
     },

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -1,9 +1,7 @@
 module.exports = () => {
     let config = {
-            flags: {
-                enableCors: true
-                graphiql: ((process.env.ENABLE_GRAPHIQL ? process.env.ENABLE_GRAPHIQL.toLowerCase() : '') === 'true')
-            },
+            enableCors: true,
+            enableGraphiql: ((process.env.ENABLE_GRAPHIQL ? process.env.ENABLE_GRAPHIQL.toLowerCase() : '') === 'true'),
             headers: {
                 graphiql: '"X-Starter-API": "Started"'
             },

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -1,7 +1,9 @@
 module.exports = () => {
     let config = {
-            enableCors: true,
-            enableGraphiql: ((process.env.ENABLE_GRAPHIQL ? process.env.ENABLE_GRAPHIQL.toLowerCase() : '') === 'true'),
+            flags: {
+                cors: true,
+                graphiql: ((process.env.ENABLE_GRAPHIQL ? process.env.ENABLE_GRAPHIQL.toLowerCase() : '') === 'true'),
+            },
             headers: {
                 graphiql: '"X-Starter-API": "Started"'
             },

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -1,20 +1,28 @@
-module.exports = {
-    headers: {
-        graphiql: '"X-Starter-API": "Started"'
-    },
-    middleware: [],
-    paths: {
-        graphql: '/graphql',
-        graphiql: '/graphiql'
-    },
-    routes: [
-        {
-            path: '/',
-            handler: function (req, res, next) {
-                res.send('Hello');
-            }
-        }
-    ],
-    resolvers: require('./resolvers'),
-    schemas: require('./schemas')
+module.exports = () => {
+    let config = {
+            flags: {
+                enableCors: true
+                graphiql: ((process.env.ENABLE_GRAPHIQL ? process.env.ENABLE_GRAPHIQL.toLowerCase() : '') === 'true')
+            },
+            headers: {
+                graphiql: '"X-Starter-API": "Started"'
+            },
+            middleware: [],
+            paths: {
+                graphql: '/graphql',
+                graphiql: '/graphiql'
+            },
+            routes: [
+                {
+                    path: '/',
+                    handler: function (req, res, next) {
+                        res.send('Hello');
+                    }
+                }
+            ],
+            resolvers: require('./resolvers'),
+            schemas: require('./schemas')
+        };
+
+    return config;
 };

--- a/example.js
+++ b/example.js
@@ -5,6 +5,9 @@ const { init } = require('./index.js'),
     };
 
 let config = {
+        flags: {
+            graphiql: true
+        },
         headers: {
             graphiql: '"X-Good": "Yes", "X-Wow": "Indeed"'
         },

--- a/example.js
+++ b/example.js
@@ -13,7 +13,10 @@ let config = {
         },
         middleware: [
             myMiddleware
-        ]
+        ],
+        paths: {
+            foo: '/bar'
+        },
     };
 
 init(config);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const server = require('cnn-server'),
     surrogateCacheControl = process.env.SURROGATE_CACHE_CONTROL || 'max-age=30, stale-while-revalidate=10, stale-if-error=6400',
     cacheControlHeader = process.env.CACHE_CONTROL || 'no-cache',
     NoIntrospection = require('graphql-disable-introspection'),
-    defaultConfig = require('./defaults/config.js'),
+    defaultConfig = require('./defaults/config.js')(),
     port = process.env.PORT || '5000';
 
 const disableIntrospection = process.env.NO_INTROSPECTION === 'true';
@@ -18,7 +18,7 @@ const headerMiddleware = (req, res, next) => {
 };
 
 function init(appConfig) {
-    const config = Object.assign({}, defaultConfig(), appConfig),
+    const config = Object.assign({}, defaultConfig, appConfig),
         schemas = config.schemas || require('./defaults/schemas'),
         resolvers = config.resolvers || require('./defaults/resolvers'),
         executableSchema = config.executableSchema || makeExecutableSchema({
@@ -28,8 +28,8 @@ function init(appConfig) {
         configRoutes = config.routes || [];
 
     // Flags
-    const enableCors = config.flags.enableCors,
-        enableGraphiql = config.flags.graphiql;
+    const enableCors = config.enableCors,
+        enableGraphiql = config.enableGraphiql;
 
     let middleware = [
             headerMiddleware,

--- a/index.js
+++ b/index.js
@@ -33,8 +33,7 @@ function init(appConfig) {
 
     let middleware = [
             headerMiddleware,
-            bodyParser.json(),
-            cors({ origin: '*' })
+            bodyParser.json()
         ],
         routes = [
             {
@@ -83,6 +82,9 @@ function init(appConfig) {
     }
 
     // Add middleware
+    if (enableCors) {
+        middleware.push(cors({ origin: '*' }));
+    }
     for (let i = 0; i < config.middleware.length; i++) {
         middleware.push(config.middleware[i]);
     }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const headerMiddleware = (req, res, next) => {
 };
 
 function init(appConfig) {
-    const config = Object.assign({}, defaultConfig, appConfig),
+    const config = Object.assign({}, defaultConfig(), appConfig),
         schemas = config.schemas || require('./defaults/schemas'),
         resolvers = config.resolvers || require('./defaults/resolvers'),
         executableSchema = config.executableSchema || makeExecutableSchema({
@@ -26,6 +26,10 @@ function init(appConfig) {
             resolvers: resolvers
         }),
         configRoutes = config.routes || [];
+
+    // Flags
+    const enableCors = config.flags.enableCors,
+        enableGraphiql = config.flags.graphiql;
 
     let middleware = [
             headerMiddleware,
@@ -61,15 +65,18 @@ function init(appConfig) {
                     return graphqlConfig;
                 }),
                 method: 'post'
-            },
-            {
-                path: config.paths.graphiql,
-                handler: graphiqlExpress({
-                    endpointURL: config.paths.graphql,
-                    passHeader: config.headers.graphiql
-                })
             }
         ];
+
+    if (enableGraphiql) {
+        routes.push({
+            path: config.paths.graphiql,
+            handler: graphiqlExpress({
+                endpointURL: config.paths.graphql,
+                passHeader: config.headers.graphiql
+            })
+        });
+    }
 
     for (let i = 0; i < configRoutes.length; i++) {
         routes.push(configRoutes[i]);

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const server = require('cnn-server'),
     { makeExecutableSchema } = require('graphql-tools'),
     { graphqlExpress, graphiqlExpress } = require('apollo-server-express'),
     bodyParser = require('body-parser'),
+    ObjectAssign = require('object-assign-deep'),
     surrogateCacheControl = process.env.SURROGATE_CACHE_CONTROL || 'max-age=30, stale-while-revalidate=10, stale-if-error=6400',
     cacheControlHeader = process.env.CACHE_CONTROL || 'no-cache',
     NoIntrospection = require('graphql-disable-introspection'),
@@ -18,7 +19,7 @@ const headerMiddleware = (req, res, next) => {
 };
 
 function init(appConfig) {
-    const config = Object.assign({}, defaultConfig, appConfig),
+    const config = ObjectAssign(defaultConfig, appConfig),
         schemas = config.schemas || require('./defaults/schemas'),
         resolvers = config.resolvers || require('./defaults/resolvers'),
         executableSchema = config.executableSchema || makeExecutableSchema({
@@ -28,8 +29,8 @@ function init(appConfig) {
         configRoutes = config.routes || [];
 
     // Flags
-    const enableCors = config.enableCors,
-        enableGraphiql = config.enableGraphiql;
+    const enableCors = config.flags.cors,
+        enableGraphiql = config.flags.graphiql;
 
     let middleware = [
             headerMiddleware,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "graphql-disable-introspection": "1.0.1",
     "graphql-tools": "2.6.1",
     "graphql-type-json": "0.1.4",
+    "object-assign-deep": "0.3.1",
     "request-promise": "4.2.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cnn-starter-api",
   "version": "1.8.0",
-  "description": "Service allows for Graphql APIs to be built in a consistent way",
+  "description": "Build Graphql APIs in a consistent way",
   "main": "index.js",
   "scripts": {
     "test": "node example.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cnn-starter-api",
   "version": "1.8.0",
-  "description": "Service that powers CNN APIs",
+  "description": "Service allows for Graphql APIs to be built in a consistent way",
   "main": "index.js",
   "scripts": {
     "test": "node example.js",


### PR DESCRIPTION
Add the ability to control if the graphiql interface will display. The interface can be controlled via the environment var `ENABLE_GRAPHIQL` or by passing a flag value when initializing the service.