### PR TITLE
Exporting a create method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,4 +103,9 @@ function init(appConfig) {
     server(serverConfig);
 }
 
-module.exports = { init };
+const create = init;
+
+module.exports = { 
+    init,
+    create
+};


### PR DESCRIPTION
# Why

cnn-starter-proxy expects a create method so we are exporting a create method in order to conform