### PR TITLE
Feature/context per request

### DIFF
--- a/src/structure/defaults/config.js
+++ b/src/structure/defaults/config.js
@@ -1,5 +1,6 @@
 module.exports = () => {
     let config = {
+        enableCompression: false,
         enableCors: true,
         enableGraphiql: ((process.env.ENABLE_GRAPHIQL ? process.env.ENABLE_GRAPHIQL.toLowerCase() : '') === 'true'),
         headers: {

--- a/src/structure/index.js
+++ b/src/structure/index.js
@@ -28,7 +28,8 @@ function init(appConfig) {
         contextPerRequest = config.contextPerRequest || {};
 
     // Flags
-    const enableCors = config.enableCors,
+    const enableCompression = config.enableCompression,
+        enableCors = config.enableCors,
         enableGraphiql = config.enableGraphiql,
         enableStatic = config.enableStatic;
 
@@ -83,7 +84,7 @@ function init(appConfig) {
                 logLevel: 'info'
             }
         },
-        enableCompression: true,
+        enableCompression: enableCompression,
         enableStatic: enableStatic,
         middleware: middleware,
         routes: routes

--- a/src/structure/index.js
+++ b/src/structure/index.js
@@ -24,47 +24,35 @@ function init(appConfig) {
             typeDefs: schemas,
             resolvers: resolvers
         }),
-        configRoutes = config.routes || [];
+        configRoutes = config.routes || [],
+        contextPerRequest = config.contextPerRequest || {};
 
     // Flags
     const enableCors = config.enableCors,
         enableGraphiql = config.enableGraphiql,
         enableStatic = config.enableStatic;
 
-    let middleware = [
+    const basicRoute = {
+        path: config.paths.graphql || 'graphql',
+        handler: graphqlExpress((req, res) => {
+            let graphqlConfig = {
+                context: contextPerRequest(req, res),
+                schema: executableSchema
+            };
+
+            if (disableIntrospection) {
+                graphqlConfig.validationRules = [NoIntrospection];
+            }
+
+            return graphqlConfig;
+        })
+    }
+
+    const routes = ['get', 'post'].map(meth => Object.assign({}, basicRoute, {method: meth}));
+
+    const middleware = [
             headerMiddleware,
             bodyParser.json()
-        ],
-        routes = [
-            {
-                path: config.paths.graphql || 'graphql',
-                handler: graphqlExpress(() => {
-                    let graphqlConfig = {
-                        schema: executableSchema
-                    };
-
-                    if (disableIntrospection) {
-                        graphqlConfig.validationRules = [NoIntrospection];
-                    }
-
-                    return graphqlConfig;
-                })
-            },
-            {
-                path: config.paths.graphql || '/graphql',
-                handler: graphqlExpress(() => {
-                    let graphqlConfig = {
-                        schema: executableSchema
-                    };
-
-                    if (disableIntrospection) {
-                        graphqlConfig.validationRules = [NoIntrospection];
-                    }
-
-                    return graphqlConfig;
-                }),
-                method: 'post'
-            }
         ];
 
     if (enableGraphiql) {


### PR DESCRIPTION
NOTE:  Disabling compression is probably not required to support setting the surrogate keys via contextPerRequest.  Perhaps should be removed form this PR and/or moved to a separate PR.