### PR TITLE
default contextPerRequest to a function returning {}

### DIFF
--- a/src/structure/index.js
+++ b/src/structure/index.js
@@ -25,7 +25,7 @@ function init(appConfig) {
             resolvers: resolvers
         }),
         configRoutes = config.routes || [],
-        contextPerRequest = config.contextPerRequest || {};
+        contextPerRequest = config.contextPerRequest || ((req, res) => ({}));
 
     // Flags
     const enableCompression = config.enableCompression,


### PR DESCRIPTION
Provide default function for contextPerRequest so that it doesn't break.