### PR TITLE
correct npm main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cnn-starter-api",
   "version": "1.21.1",
   "description": "Build Graphql APIs in a consistent way",
-  "main": "./src/structure/index.js",
+  "main": "./src/graphql/structure/index.js",
   "license": "Apache-2.0",
   "author": "A.D. Slaton <ad.slaton@turner.com>",
   "bin": {


### PR DESCRIPTION
# Why

Our recent changes to add Hapi support broke the main file path. Updating the path so that this module can function as expected.